### PR TITLE
change the format of filename

### DIFF
--- a/filelog.go
+++ b/filelog.go
@@ -139,9 +139,17 @@ func (w *FileLogWriter) intRotate() error {
 			// Find the next available number
 			num := 1
 			fname := ""
-			for ; err == nil && num <= 999; num++ {
-				fname = w.filename + fmt.Sprintf(".%s.%03d", time.Now().Format("2006-01-02"), num)
-				_, err = os.Lstat(fname)
+			if w.daily && time.Now().Day() != w.daily_opendate {
+				yesterday := time.Now().AddDate(0, 0, -1).Format("2006-01-02")
+				for ; err == nil && num <= 999; num++ {
+					fname = w.filename + fmt.Sprintf(".%s.%03d", yesterday, num)
+					_, err = os.Lstat(fname)
+				}
+			} else {
+				for ; err == nil && num <= 999; num++ {
+					fname = w.filename + fmt.Sprintf(".%s.%03d", time.Now().Format("2006-01-02"), num)
+					_, err = os.Lstat(fname)
+				}
 			}
 			// return error if the last file checked still existed
 			if err == nil {


### PR DESCRIPTION
Many logfiles need to be separated by date. 
And the logfile name with the date will help us to find specific file.
So add date format in filelog.go
What's more, it is safer to close the file before rename it.
