### PR TITLE
Fix an annoying issue in example code.

### DIFF
--- a/examples/ConsoleLogWriter_Manual.go
+++ b/examples/ConsoleLogWriter_Manual.go
@@ -8,6 +8,7 @@ import l4g "code.google.com/p/log4go"
 
 func main() {
 	log := l4g.NewLogger()
+	defer log.Close()
 	log.AddFilter("stdout", l4g.DEBUG, l4g.NewConsoleLogWriter())
 	log.Info("The time is now: %s", time.Now().Format("15:04:05 MST 2006/01/02"))
 }


### PR DESCRIPTION
Console example should include Close method, otherwise you will not get log printout properly.